### PR TITLE
Automatically convert datetime to date.

### DIFF
--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -5,7 +5,7 @@ import ephem
 import pytz
 
 from calendar import monthrange
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from math import pi
 
 from dateutil import easter
@@ -83,6 +83,10 @@ class Calendar(object):
         ``extra_holidays`` list.
 
         """
+        # a little exception: chop the datetime type
+        if type(day) is datetime:
+            day = day.date()
+
         # Extra lists exceptions
         if extra_working_days and day in extra_working_days:
             return True

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import datetime
 from workalendar.tests import GenericCalendarTest
 from workalendar.core import MON, TUE, THU, FRI
 from workalendar.core import Calendar, LunarCalendar
@@ -194,6 +195,10 @@ class MockCalendarTest(GenericCalendarTest):
                                     extra_holidays=extra_holidays))
         # test is_holiday
         self.assertTrue(self.cal.is_holiday(christmas))
+
+    def test_datetime(self):
+        self.assertFalse(
+            self.cal.is_working_day(datetime(2014, 1, 1)))
 
 
 class IslamicMixinTest(GenericCalendarTest):


### PR DESCRIPTION
Currently `is_working_day()` doesn't respond correctly if you give it a `datetime` object as opposed to just a `date` object. It correctly reports weekends, but not holidays:

```
>>> uk.is_working_day(datetime.datetime(2014, 4, 21))
True
>>> uk.is_working_day(datetime.datetime(2014, 4, 21).date())
False
```
