### PR TITLE
Dist fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,28 +32,30 @@ if PY2:
 else:
     REQUIREMENTS.append('ephem')
 
+params = dict(
+    name=NAME,
+    description=DESCRIPTION,
+    packages=['workalendar'],
+    version=__VERSION__,
+    long_description=read_relative_file('README.rst'),
+    author='Bruno Bord',
+    author_email='bruno.bord@novapost.fr',
+    url='https://github.com/novapost/workalendar',
+    license='MIT License',
+    include_package_data=True,
+    install_requires=REQUIREMENTS,
+    zip_safe=False,
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+    ],
+)
+
 if __name__ == '__main__':
-    setup(
-        name=NAME,
-        description=DESCRIPTION,
-        packages=['workalendar'],
-        version=__VERSION__,
-        long_description=read_relative_file('README.rst'),
-        author='Bruno Bord',
-        author_email='bruno.bord@novapost.fr',
-        url='https://github.com/novapost/workalendar',
-        license='MIT License',
-        include_package_data=True,
-        install_requires=REQUIREMENTS,
-        zip_safe=False,
-        classifiers=[
-            'Development Status :: 4 - Beta',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: MIT License',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.3',
-        ],
-    )
+    setup(**params)


### PR DESCRIPTION
This PR includes two commits. The first is a fix for a bug. When using the distutils upload command, the upload would fail with this error:

```
running upload
Traceback (most recent call last):
  File "C:\Users\jaraco\projects\workalendar\setup.py", line 57, in <module>
    'Programming Language :: Python :: 3.3',
  File "c:\python\lib\distutils\core.py", line 149, in setup
    dist.run_commands()
  File "c:\python\lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "c:\python\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "c:\python\lib\distutils\command\upload.py", line 65, in run
    self.upload_file(command, pyversion, filename)
  File "c:\python\lib\distutils\command\upload.py", line 163, in upload_file
    body.write(value)
TypeError: 'str' does not support the buffer interface
```

It turns out that distutils is very particular about the types of the 'classifiers' (or any other value passed as metadata). If it's a tuple, it assumes it's a two-tuple of file/content. Because 'classifiers' was a tuple, the first two values were being loaded as file/content and the rest discarded, but since the second classifier was a string and not bytes, it was failing the upload. Making classifiers a list fixes this problem.

The second change is more stylistic, but it's a pattern which I've adopted and treats me well.

Feel free to accept the PR as-is, pull only the first commit, or ask me to update the PR to exclude the second change.
