### PR TITLE
European Central Bank holidays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ Europe
 ------
 
 * Czech Republic
+* European Central Bank
 * Finland
 * France
 * France (Alsace / Moselle)

--- a/workalendar/europe.py
+++ b/workalendar/europe.py
@@ -326,3 +326,13 @@ class UnitedKingdomNorthernIreland(UnitedKingdom):
                 self.find_following_working_day(battle_of_boyne),
                 "Battle of the Boyne substitute"))
         return days
+
+
+class EuropeanCentralBank(WesternCalendar, ChristianMixin):
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (5, 1, "Labour Day"),
+        (12, 26, "St. Stephen's Day"),
+    )
+
+    include_good_friday = True
+    include_easter_monday = True

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -12,6 +12,7 @@ from workalendar.europe import Norway
 from workalendar.europe import Poland
 from workalendar.europe import UnitedKingdom
 from workalendar.europe import UnitedKingdomNorthernIreland
+from workalendar.europe import EuropeanCentralBank
 
 
 class CzechRepublicTest(GenericCalendarTest):
@@ -333,3 +334,16 @@ class UnitedKingdomNorthernIrelandTest(UnitedKingdomTest):
         holidays = self.cal.holidays_set(2014)
         self.assertIn(date(2014, 7, 12), holidays)  # Battle of the Boyne
         self.assertIn(date(2014, 7, 14), holidays)  # Battle of the Boyne sub
+
+
+class EuropeanCentralBankTest(GenericCalendarTest):
+    cal_class = EuropeanCentralBank
+
+    def test_year_2014(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 1, 1), holidays)  # New year's day
+        self.assertIn(date(2014, 4, 18), holidays)  # Good friday
+        self.assertIn(date(2014, 4, 21), holidays)  # easter monday
+        self.assertIn(date(2014, 5, 1), holidays)  # Labour day
+        self.assertIn(date(2014, 12, 25), holidays)  # XMas
+        self.assertIn(date(2014, 12, 26), holidays)  # St Stephen


### PR DESCRIPTION
As a follow-up of a conversation with @mcgohier at the European Django Conference, it appeared that the European Central Bank has set its own holiday calendar.

references:
- http://www.cambiste.info/sdmpage/dates/datval30.php,
- http://www.cambiste.info/sdmpage/dates/ecb_press.html
