### PR TITLE
Corpus Christi is a working day in France (fix and unit test included).

### DIFF
--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -205,7 +205,7 @@ class ChristianMixin(Calendar):
     whit_sunday_label = 'Whit Sunday'
     include_whit_monday = False
     whit_monday_label = 'Whit Monday'
-    include_corpus_christi = True
+    include_corpus_christi = False
     include_boxing_day = False
     boxing_day_label = "Boxing Day"
 

--- a/workalendar/europe.py
+++ b/workalendar/europe.py
@@ -118,7 +118,6 @@ class France(WesternCalendar, ChristianMixin):
     include_whit_monday = True
     include_all_saints = True
     include_assumption = True
-    include_corpus_christi = False
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (5, 1, "Labour Day"),


### PR DESCRIPTION
I'm using workalendar in the French company I'm working for. In France "Corpus Christi" is not a day off.
Source (fr): http://fr.wikipedia.org/wiki/F%C3%AAte-Dieu

> En vertu d'une dérogation prévue par les livres liturgiques dont l'application relève de l'autorité des évêques et des conférences épiscopales des pays concernés, elle est reportée au dimanche qui suit la Sainte-Trinité dans les pays où elle n'est pas inscrite au nombre des jours chômés (France, Italie - depuis 1977, etc.)
