### PR TITLE
Support building on systems where LANG=C (Ubuntu)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 #-*- coding: utf-8 -*-
+import io
 from os.path import join, dirname, abspath
 import sys
 
@@ -15,7 +16,7 @@ def read_relative_file(filename):
     """Returns contents of the given file, whose path is supposed relative
     to this module."""
     path = join(dirname(abspath(__file__)), filename)
-    with open(path) as f:
+    with io.open(path, encoding='utf-8') as f:
         return f.read()
 
 NAME = 'workalendar'


### PR DESCRIPTION
On systems such as Ubuntu, where LANG=C, the default encoding on Python 3 ends up being "ascii", which fails with a UnicodeDecodeError when attempting to decode the changelog. This change corrects that and is a technique I've been using in Portend for some weeks now with good success and portability.
