### PR TITLE
Boxing Day is not being shifted when it falls on a Saturday

### DIFF
--- a/workalendar/europe.py
+++ b/workalendar/europe.py
@@ -299,10 +299,14 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         days.append(self.get_late_summer_bank_holiday(year))
         # Boxing day & XMas shift
         christmas = date(year, 12, 25)
+        boxing_day = date(year, 12, 26)
         if christmas.weekday() in self.get_weekend_days():
             shift = self.find_following_working_day(christmas)
             days.append((shift, "Christmas Shift"))
             days.append((shift + timedelta(days=1), "Boxing Day Shift"))
+        elif boxing_day.weekday() in self.get_weekend_days():
+            shift = self.find_following_working_day(boxing_day)
+            days.append((shift, "Boxing Day Shift"))
         return days
 
 

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -327,6 +327,12 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2011, 12, 26), holidays)  # XMas day shift
         self.assertIn(date(2011, 12, 27), holidays)  # Boxing day shift
 
+    def test_shift_2015(self):
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 12, 25), holidays)  # Christmas it's friday
+        self.assertIn(date(2015, 12, 26), holidays)  # Boxing day it's saturday
+        self.assertIn(date(2015, 12, 28), holidays)  # Boxing day shift
+
 
 class UnitedKingdomNorthernIrelandTest(UnitedKingdomTest):
     cal_class = UnitedKingdomNorthernIreland


### PR DESCRIPTION
In the UK and Northern Ireland, holiday days are observed in lieu of Christmas Day and Boxing Day if either of those days falls on a weekend. The current logic for shifting these dates (in `workalendar.europe`) is only triggered when Christmas Day falls on a weekend and so does not account for the scenario where Christmas Day falls on a Friday, meaning that Boxing Day is on a Saturday and should be shifted to the following Monday.

Please review my changes in `workalendar.europe`, where I've added an additional clause to account for this particular scenario. I've also added a unit test in `test_europe.UnitedKingdom`.

Hope this is correct.

P.S. thanks for the great library!
- D
