### PR TITLE
Add Nigeria calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Added Nigeria calendar by @taiyeoguns
 
 ## v15.3.1 (2021-07-02)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-- Added Nigeria calendar by @taiyeoguns
+- Added Nigeria calendar by @taiyeoguns (#656)
 
 ## v15.3.1 (2021-07-02)
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ from the command line.
 - Kenya
 - Madagascar
 - Mozambique
+- Nigeria
 - São Tomé
 - South Africa
 

--- a/workalendar/africa/__init__.py
+++ b/workalendar/africa/__init__.py
@@ -7,6 +7,7 @@ from .sao_tome import SaoTomeAndPrincipe
 from .south_africa import SouthAfrica
 from .angola import Angola
 from .mozambique import Mozambique
+from .nigeria import Nigeria
 
 __all__ = (
     'Algeria',
@@ -18,4 +19,5 @@ __all__ = (
     'SouthAfrica',
     'Angola',
     'Mozambique',
+    'Nigeria',
 )

--- a/workalendar/africa/nigeria.py
+++ b/workalendar/africa/nigeria.py
@@ -1,0 +1,53 @@
+from datetime import date
+
+from ..core import IslamoWesternCalendar, SAT, SUN
+from ..registry_tools import iso_register
+
+
+@iso_register("NG")
+class Nigeria(IslamoWesternCalendar):
+    "Nigeria"
+
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Workers' Day"
+
+    # Christian holidays
+    include_good_friday = True
+    include_easter_monday = True
+    include_boxing_day = True
+
+    # Islamic holidays
+    include_eid_al_fitr = True
+    include_day_of_sacrifice = True
+
+    shift_sunday_holidays = True
+    shift_new_years_day = True
+
+    # Explicitly assign these WE days, Nigeria has adopted the western workweek
+    WEEKEND_DAYS = (SAT, SUN)
+
+    FIXED_HOLIDAYS = IslamoWesternCalendar.FIXED_HOLIDAYS + (
+        (10, 1, "Independence Day"),
+    )
+
+    def get_fixed_holidays(self, year):
+        """Get fixed holidays.
+
+        Args:
+            year (int): Year
+
+        Returns:
+            tuple: Tuple of date and label
+        """
+        days = super().get_fixed_holidays(year)
+
+        democracy_day_label = "Democracy Day"
+
+        if 2000 <= year < 2018:
+            days.append((date(year, 5, 29), democracy_day_label))
+
+        if year >= 2018:
+            days.append((date(year, 6, 12), democracy_day_label))
+
+        return days

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -7,6 +7,7 @@ from ..africa import (
     IvoryCoast,
     Kenya,
     Madagascar,
+    Nigeria,
     SaoTomeAndPrincipe,
     SouthAfrica,
 )
@@ -605,3 +606,29 @@ class KenyaTest(GenericCalendarTest):
         self.assertIn(date(2020, 12, 26), holidays)  # Utamaduni Day
         self.assertIn(date(2020, 12, 31), holidays)  # New Years Eve
         self.assertEqual(len(holidays), 14)
+
+
+class NigeriaTest(GenericCalendarTest):
+    cal_class = Nigeria
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 1), holidays)  # New Year
+        self.assertIn(date(2019, 4, 19), holidays)  # Good Friday
+        self.assertIn(date(2019, 4, 22), holidays)  # Easter Monday
+        self.assertIn(date(2019, 5, 1), holidays)  # Workers Day
+        self.assertIn(date(2019, 6, 5), holidays)  # Eid al-Fitr
+        self.assertIn(date(2019, 6, 12), holidays)  # Democracy Day
+        self.assertIn(date(2019, 10, 1), holidays)  # Independence Day
+        self.assertIn(date(2019, 8, 12), holidays)  # Eid al-Adha
+        self.assertIn(date(2019, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2019, 12, 26), holidays)  # Boxing Day
+
+    def test_year_2000(self):
+        holidays = self.cal.holidays_set(2000)
+        self.assertIn(date(2000, 5, 29), holidays)  # Former Democracy Day
+
+    def test_year_1998(self):
+        holidays = self.cal.holidays_set(1998)
+        self.assertNotIn(date(1998, 5, 29), holidays)  # No Democracy Day yet
+        self.assertNotIn(date(1998, 6, 12), holidays)  # No Democracy Day yet


### PR DESCRIPTION
Add Nigeria calendar.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.md file.
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
