### PR TITLE
Updated Japan calendar because of the Olympics. (#662)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - The Workalendar project has been moved from Peopledoc's organization to its own (#651, #653, thx to @ewjoachim).
+- Updated Japan calendar because of the Olympics. (#662)
 
 ## v15.3.0 (2021-05-07)
 

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -56,16 +56,12 @@ class Japan(Calendar):
             days.remove((date(year, 8, 11), "Mountain Day"))
         if year == 2021:
             days.extend([
-                (date(year, 7, 22), "Marine Day"),
-                (date(year, 7, 23), "Sports Day"),
                 (date(year, 8, 8), "Mountain Day"),
                 (date(year, 8, 9), "Mountain Day Observed"),
             ])
-            # Marine Day, Sports Day and Mountain Day change in 2021 because of the Olympics.
+            # Mountain Day change in 2021 because of the Olympics.
             # https://www.kantei.go.jp/jp/headline/tokyo2020/shukujitsu.html
-            days.remove((date(year, 7, 19), "Marine Day"))
             days.remove((date(year, 8, 11), "Mountain Day"))
-            days.remove((date(year, 10, 11), "Health and Sports Day"))
         return days
 
     def get_variable_days(self, year):
@@ -95,6 +91,13 @@ class Japan(Calendar):
             days.append((date(2020, 7, 23), "Marine Day"))
             days.remove((health_and_sport, "Health and Sports Day"))
             days.append((date(2020, 7, 24), "Health and Sports Day"))
+        # Marine Day and Sports Day change in 2021 because of the Olympics.
+        # https://www.kantei.go.jp/jp/headline/tokyo2020/shukujitsu.html
+        if year == 2021:
+            days.remove((date(year, 7, 19), "Marine Day"))
+            days.append((date(year, 7, 22), "Marine Day"))
+            days.remove((date(year, 10, 11), "Health and Sports Day"))
+            days.append((date(year, 7, 23), "Sports Day"))
         return days
 
 

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -54,6 +54,18 @@ class Japan(Calendar):
             # Mountain Day is 8/10 this year for some reason
             # The next year that will be different is 2024
             days.remove((date(year, 8, 11), "Mountain Day"))
+        if year == 2021:
+            days.extend([
+                (date(year, 7, 22), "Marine Day"),
+                (date(year, 7, 23), "Sports Day"),
+                (date(year, 8, 8), "Mountain Day"),
+                (date(year, 8, 9), "Mountain Day Observed"),
+            ])
+            # Marine Day, Sports Day and Mountain Day change in 2021 because of the Olympics.
+            # https://www.kantei.go.jp/jp/headline/tokyo2020/shukujitsu.html
+            days.remove((date(year, 7, 19), "Marine Day"))
+            days.remove((date(year, 8, 11), "Mountain Day"))
+            days.remove((date(year, 10, 11), "Health and Sports Day"))
         return days
 
     def get_variable_days(self, year):

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -363,6 +363,16 @@ class JapanTest(GenericCalendarTest):
         self.assertNotIn(date(2020, 8, 11), holidays)  # Mountain Day
         self.assertNotIn(date(2020, 12, 31), holidays)  # New Year's Bank Day
 
+    def test_year_2021(self):
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 7, 22), holidays) # Marine Day
+        self.assertIn(date(2021, 7, 23), holidays) # Sports Dat
+        self.assertIn(date(2021, 8, 8), holidays) # Mountain Day
+        self.assertIn(date(2021, 8, 9), holidays) # Mountain Day Observed
+        self.assertNotIn(date(2021, 7, 19), holidays) # Marine Day
+        self.assertNotIn(date(2021, 8, 11), holidays) # Mountain Day
+        self.assertNotIn(date(2021, 10, 11), holidays) # Sports Day
+
 
 class JapanBankTest(GenericCalendarTest):
     cal_class = JapanBank


### PR DESCRIPTION
- Changes Marine Day from 2021/7/19 to 2021/7/22
- Changes Sports Day from 2021/10/11 to 2021/7/23
- Changes Mountains Day from 2021/8/11 to 2021/8/8
- Add Mountains Day Observed on 2021/8/9

refs #

<!-- if your contribution is a new calendar -->

For information, read and make sure you're okay with the [Contributing guidelines](https://peopledoc.github.io/workalendar/contributing.html#adding-new-calendars).

- [ ] Tests with a significant number of years to be tested for your calendar.
- [ ] Docstrings for the Calendar class and specific methods.
- [ ] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [ ] Calendar country / label added to the README.md file.
- [ ] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

<!-- if your contribution is a fix -->

- [ ] Tests with a significant number of years to be tested for your calendar.
- [ ] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

<!-- Release management

- Commit for the tag:
    - [ ] Edit version in setup.cfg
    - [ ] Add version in Changelog.md ; trim things
    - [ ] Push & wait for the tests to be green
    - [ ] tag me.
    - [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [ ] Edit version in setup.cfg
    - [ ] Add the "master / nothing to see here" in Changelog.md
    - [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.

 -->
