### PR TITLE
Japan calendar update because of the 2021 Olympics

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - The Workalendar project has been moved from Peopledoc's organization to its own (#651, #653, thx to @ewjoachim).
+- Updated Japan calendar because of the Olympics, thx @lxlgarnett. (#662)
 
 ## v15.3.0 (2021-05-07)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - The Workalendar project has been moved from Peopledoc's organization to its own (#651, #653, thx to @ewjoachim).
 - Updated Japan calendar because of the Olympics, thx @lxlgarnett. (#662)
+- Fixed Japan "Sports Day" label depending on the year.
 
 ## v15.3.0 (2021-05-07)
 

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -85,13 +85,19 @@ class Japan(Calendar):
             marine_day = Japan.get_nth_weekday_in_month(year, 7, MON, 3)
             health_and_sport = Japan.get_nth_weekday_in_month(year, 10, MON, 2)
 
+        # Health and Sports Day became "Sports Day" as of 2020
+        if year < 2020:
+            health_and_sport_label = "Health and Sports Day"
+        else:
+            health_and_sport_label = "Sports Day"
+
         days.extend([
             (coming_of_age_day, 'Coming of Age Day'),
             (marine_day, "Marine Day"),
             (equinoxes[0], "Vernal Equinox Day"),
             (respect_for_the_aged, "Respect-for-the-Aged Day"),
             (equinoxes[1], "Autumnal Equinox Day"),
-            (health_and_sport, "Health and Sports Day"),
+            (health_and_sport, health_and_sport_label),
         ])
 
         return days

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -27,7 +27,7 @@ class Japan(Calendar):
         Fixed holidays for Japan.
         """
         days = super().get_fixed_holidays(year)
-        if year >= 2016:
+        if year >= 2016 and year != 2021:
             days.append((date(year, 8, 11), "Mountain Day"))
         # Change in Emperor
         if year < 2019:
@@ -54,6 +54,12 @@ class Japan(Calendar):
             # Mountain Day is 8/10 this year for some reason
             # The next year that will be different is 2024
             days.remove((date(year, 8, 11), "Mountain Day"))
+        if year == 2021:
+            # Mountain Day is changed due to Tokyo's Olympics
+            days.extend([
+                (date(year, 8, 8), "Mountain Day"),
+                (date(year, 8, 9), "Mountain Day Observed"),
+            ])
         return days
 
     def get_variable_days(self, year):
@@ -61,9 +67,24 @@ class Japan(Calendar):
         days = super().get_variable_days(year)
         equinoxes = calculate_equinoxes(year, 'Asia/Tokyo')
         coming_of_age_day = Japan.get_nth_weekday_in_month(year, 1, MON, 2)
-        marine_day = Japan.get_nth_weekday_in_month(year, 7, MON, 3)
         respect_for_the_aged = Japan.get_nth_weekday_in_month(year, 9, MON, 3)
-        health_and_sport = Japan.get_nth_weekday_in_month(year, 10, MON, 2)
+
+        if year == 2020:
+            # Health and Sports Day will continue on the 2nd monday
+            # of October, except in 2020 when it will happen in July
+            # https://www.timeanddate.com/holidays/japan/sports-day
+            marine_day = date(2020, 7, 23)
+            health_and_sport = date(2020, 7, 24)
+        elif year == 2021:
+            # Marine Day & Sport's Day are changed due to Tokyo's Olympics
+            marine_day = date(year, 7, 22)
+            health_and_sport = date(year, 7, 23)
+        else:
+            # Marine Day is on a Thursday in 2020 for some year
+            # https://www.timeanddate.com/holidays/japan/sea-day
+            marine_day = Japan.get_nth_weekday_in_month(year, 7, MON, 3)
+            health_and_sport = Japan.get_nth_weekday_in_month(year, 10, MON, 2)
+
         days.extend([
             (coming_of_age_day, 'Coming of Age Day'),
             (marine_day, "Marine Day"),
@@ -73,16 +94,6 @@ class Japan(Calendar):
             (health_and_sport, "Health and Sports Day"),
         ])
 
-        # Marine Day is on a Thursday in 2020 for some year
-        # https://www.timeanddate.com/holidays/japan/sea-day
-        # Health and Sports Day will continue on the 2nd monday
-        # of October, except in 2020 when it will happen in July
-        # https://www.timeanddate.com/holidays/japan/sports-day
-        if year == 2020:
-            days.remove((marine_day, "Marine Day"))
-            days.append((date(2020, 7, 23), "Marine Day"))
-            days.remove((health_and_sport, "Health and Sports Day"))
-            days.append((date(2020, 7, 24), "Health and Sports Day"))
         return days
 
 

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -354,6 +354,11 @@ class JapanTest(GenericCalendarTest):
         self.assertIn(date(2019, 5, 6), holidays)  # Children's Day
         self.assertIn(date(2019, 8, 12), holidays)  # Mountain Day Observed
         self.assertIn(date(2019, 11, 4), holidays)  # Culture Day Observed
+        # retrieve the sports day label
+        holidays = self.cal.holidays(2019)
+        holidays_dict = dict(holidays)
+        self.assertEqual(
+            holidays_dict[date(2019, 10, 14)], "Health and Sports Day")
 
     def test_year_2020(self):
         holidays = self.cal.holidays_set(2020)
@@ -362,16 +367,24 @@ class JapanTest(GenericCalendarTest):
         self.assertIn(date(2020, 8, 10), holidays)  # Mountain Day adjustment
         self.assertNotIn(date(2020, 8, 11), holidays)  # Mountain Day
         self.assertNotIn(date(2020, 12, 31), holidays)  # New Year's Bank Day
+        # retrieve the sports day label
+        holidays = self.cal.holidays(2020)
+        holidays_dict = dict(holidays)
+        self.assertEqual(holidays_dict[date(2020, 7, 24)], "Sports Day")
 
     def test_year_2021(self):
         holidays = self.cal.holidays_set(2021)
         self.assertIn(date(2021, 7, 22), holidays)  # Marine Day
-        self.assertIn(date(2021, 7, 23), holidays)  # Sports Dat
+        self.assertIn(date(2021, 7, 23), holidays)  # Sports Day
         self.assertIn(date(2021, 8, 8), holidays)  # Mountain Day
         self.assertIn(date(2021, 8, 9), holidays)  # Mountain Day Observed
         self.assertNotIn(date(2021, 7, 19), holidays)  # Marine Day
         self.assertNotIn(date(2021, 8, 11), holidays)  # Mountain Day
         self.assertNotIn(date(2021, 10, 11), holidays)  # Sports Day
+        # retrieve the sports day label
+        holidays = self.cal.holidays(2021)
+        holidays_dict = dict(holidays)
+        self.assertEqual(holidays_dict[date(2021, 7, 23)], "Sports Day")
 
 
 class JapanBankTest(GenericCalendarTest):

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -363,6 +363,16 @@ class JapanTest(GenericCalendarTest):
         self.assertNotIn(date(2020, 8, 11), holidays)  # Mountain Day
         self.assertNotIn(date(2020, 12, 31), holidays)  # New Year's Bank Day
 
+    def test_year_2021(self):
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 7, 22), holidays)  # Marine Day
+        self.assertIn(date(2021, 7, 23), holidays)  # Sports Dat
+        self.assertIn(date(2021, 8, 8), holidays)  # Mountain Day
+        self.assertIn(date(2021, 8, 9), holidays)  # Mountain Day Observed
+        self.assertNotIn(date(2021, 7, 19), holidays)  # Marine Day
+        self.assertNotIn(date(2021, 8, 11), holidays)  # Mountain Day
+        self.assertNotIn(date(2021, 10, 11), holidays)  # Sports Day
+
 
 class JapanBankTest(GenericCalendarTest):
     cal_class = JapanBank


### PR DESCRIPTION
refs #662 / superseeds and thus closes #663


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
- [x] Rebase / Squash

