### PR TITLE
Replace calverter with convertdate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Replace `pyCalverter` with `convertdate` (#536)
+- Remove unused `JalaliMixin`
 
 ## v15.4.0 (2021-07-12)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,6 @@ install_requires =
     lunardate
     backports.zoneinfo;python_version<"3.9"
     tzdata;platform_system=="Windows"
-    pyCalverter
+    convertdate
     pyluach
     setuptools>=1.0

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -10,7 +10,7 @@ from ..core import (
     MON, TUE, THU, FRI, WED, SAT, SUN,
     ISO_TUE, ISO_FRI,
     Calendar, LunarMixin, WesternCalendar,
-    CalverterMixin, IslamicMixin, JalaliMixin,
+    CalverterMixin, IslamicMixin,
     daterange,
 )
 from ..exceptions import UnsupportedDateType, CalendarError
@@ -271,14 +271,6 @@ class MockCalendarTest(CoreCalendarTest):
 
 class IslamicMixinTest(CoreCalendarTest):
     cal_class = IslamicMixin
-
-    def test_year_conversion(self):
-        days = self.cal.converted(2013)
-        self.assertEqual(len(days), 365)
-
-
-class JalaliMixinTest(CoreCalendarTest):
-    cal_class = JalaliMixin
 
     def test_year_conversion(self):
         days = self.cal.converted(2013)


### PR DESCRIPTION
refs #536

This PR replaces `pyCalverter`, which is no more mantained and has an incompatible license (GPLv2), with [`convertdate`](https://pypi.org/project/convertdate/).


- [ ] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

