### PR TITLE
Add Guernsey

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 ### New calendar
 
 - New calendar: Added Philippines calendar by @micodls (#396)
+- New calendar: Added Guernsey calendar by @ludsoft (#681)
 
 ### Internal changes
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ from the command line.
 - France (Alsace / Moselle)
 - Germany
 - Greece
+- Guernsey
 - Hungary
 - Iceland
 - Ireland

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -12,6 +12,7 @@ from .denmark import Denmark
 from .finland import Finland
 from .france import France, FranceAlsaceMoselle
 from .greece import Greece
+from .guernsey import Guernsey
 from .hungary import Hungary
 from .iceland import Iceland
 from .ireland import Ireland
@@ -82,6 +83,7 @@ __all__ = (
     'France',
     'FranceAlsaceMoselle',
     'Greece',
+    'Guernsey',
     'Hungary',
     'Iceland',
     'Ireland',

--- a/workalendar/europe/guernsey.py
+++ b/workalendar/europe/guernsey.py
@@ -1,0 +1,58 @@
+from datetime import date
+
+from ..core import MON, WesternCalendar
+from ..registry_tools import iso_register
+
+
+@iso_register('GG')
+class Guernsey(WesternCalendar):
+    'Guernsey'
+
+    include_easter_monday = True
+    include_boxing_day = True
+    shift_new_years_day = True
+    include_good_friday = True
+
+    def get_spring_bank_holiday(self, year):
+        spring_bank_holiday = Guernsey \
+            .get_last_weekday_in_month(year, 5, MON)
+        return (
+            spring_bank_holiday,
+            "Spring Bank Holiday"
+        )
+
+    def get_early_may_bank_holiday(self, year):
+        """
+        Return Early May bank holiday
+        """
+        # Special case in 2020, for the 75th anniversary of the end of WWII.
+        if year == 2020:
+            return (
+                date(year, 5, 8),
+                "Early May bank holiday (VE day)"
+            )
+
+        return (
+            Guernsey.get_nth_weekday_in_month(year, 5, MON),
+            "Early May Bank Holiday"
+        )
+
+    def get_summer_bank_holiday(self, year):
+        return (
+            Guernsey.get_last_weekday_in_month(year, 8, MON),
+            "Summer Bank Holiday"
+        )
+
+    def get_liberation_day(self, year):
+        return (date(year, 5, 9), "Liberation Day")
+
+    def get_variable_days(self, year):
+        days = super().get_variable_days(year)
+        days.append(self.get_early_may_bank_holiday(year))
+        days.append(self.get_spring_bank_holiday(year))
+        days.append(self.get_summer_bank_holiday(year))
+        days.append(self.get_liberation_day(year))
+        # Boxing day & XMas shift
+        shifts = self.shift_christmas_boxing_days(year=year)
+        days.extend(shifts)
+        return days

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -20,6 +20,7 @@ from ..europe import (
     Sweden,
     France, FranceAlsaceMoselle,
     Greece,
+    Guernsey,
     Hungary,
     Iceland,
     Ireland,
@@ -43,8 +44,6 @@ from ..europe import (
     UnitedKingdomNorthernIreland,
     EuropeanCentralBank,
 )
-
-
 # Tests dedicated to Netherlands School holidays
 from ..europe.netherlands import (
     SPRING_HOLIDAYS_EARLY_REGIONS,
@@ -1904,6 +1903,57 @@ class UnitedKingdomNorthernIrelandTest(UnitedKingdomTest):
         holidays = self.cal.holidays_set(2014)
         self.assertIn(date(2014, 7, 12), holidays)  # Battle of the Boyne
         self.assertIn(date(2014, 7, 14), holidays)  # Battle of the Boyne sub
+
+
+class GuernseyTest(GenericCalendarTest):
+    cal_class = Guernsey
+
+    def test_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 1, 1), holidays)  # New Year
+        self.assertIn(date(2020, 4, 10), holidays)  # Good Friday
+        self.assertIn(date(2020, 4, 13), holidays)  # Easter Monday
+        # This is where the year 2020 becomes special:
+        # The Early May Bank Holiday has been moved to May 8th
+        # to commemorate the 75th anniversary of the end of WWII
+        self.assertNotIn(date(2020, 5, 4), holidays)
+        self.assertIn(date(2020, 5, 25), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2020, 8, 31), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2020, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2020, 12, 26), holidays)  # 'Boxing Day
+        self.assertIn(date(2020, 12, 28), holidays)  # Boxing Day Shift
+
+        # May the 8th is VE day
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertIn(date(2020, 5, 8), holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 8)], "Early May bank holiday (VE day)"
+        )
+
+    def test_2021(self):
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 1, 1), holidays)  # New Year
+        self.assertIn(date(2021, 4, 2), holidays)  # Good Friday
+        self.assertIn(date(2021, 4, 5), holidays)  # Easter Monday
+        self.assertIn(date(2021, 5, 3), holidays)  # May Day Bank Holiday
+        self.assertIn(date(2021, 5, 9), holidays)  # Liberation Day
+        self.assertIn(date(2021, 5, 31), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2021, 8, 30), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2021, 12, 27), holidays)  # Christmas Day
+        self.assertIn(date(2021, 12, 28), holidays)  # Boxing Day Shift
+
+    def test_2022(self):
+        holidays = self.cal.holidays_set(2022)
+        self.assertIn(date(2022, 1, 3), holidays)  # New Year
+        self.assertIn(date(2022, 4, 15), holidays)  # Good Friday
+        self.assertIn(date(2022, 4, 18), holidays)  # Easter Monday
+        self.assertIn(date(2022, 5, 2), holidays)  # May Day bank Holiday
+        self.assertIn(date(2022, 5, 9), holidays)  # Liberation Day
+        self.assertIn(date(2022, 5, 30), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2022, 8, 29), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2022, 12, 26), holidays)  # 'Boxing Day
+        self.assertIn(date(2022, 12, 27), holidays)  # Christmas Day
 
 
 class EuropeanCentralBankTest(GenericCalendarTest):


### PR DESCRIPTION
Add a new calendar for Guernsey. 
Here is the official website followed to implement the rule: https://gov.gg/holidaydates

One thing to note is that there are many similarities with the UK calendar but I've not tried to couple the two as there are some custom day shift in the UK that are not followed by Guernsey for what I can find. So it seems more trouble than it is worth. 

refs #


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.md file.
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

