### PR TITLE
Remove duplicate Proclamation Day for Latvia

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Removed duplicate Proclamation Day for Latvia
 
 ## v16.1.0 (2021-10-01)
 

--- a/workalendar/europe/latvia.py
+++ b/workalendar/europe/latvia.py
@@ -12,7 +12,6 @@ class Latvia(WesternCalendar):
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (6, 23, "Midsummer Day"),
         (6, 24, "St. John's Day"),
-        (11, 18, "Proclamation Day"),
         (12, 31, "New Years Eve"),
     )
 


### PR DESCRIPTION
Noticed that there are duplicate Proclamation Day entries for Latvia as it was both present in `FIXED_HOLIDAYS` and also in `get_republic_days` function. Removed it from `FIXED_HOLIDAYS`.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

