### PR TITLE
Update China's public holidays for 2022.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Update China's public holidays for 2022.
 
 ## v16.1.0 (2021-10-01)
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -86,7 +86,7 @@ workdays = {
 @iso_register('CN')
 class China(ChineseNewYearCalendar):
     "China"
-    # WARNING: Support 2018, 2019 currently, need update every year.
+    # WARNING: Support 2018-2022 currently, need update every year.
     shift_new_years_day = True
     # National Days, 10.1 - 10.7
     national_days = [(10, i, "National Day") for i in range(1, 8)]

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -35,6 +35,13 @@ holidays = {
             'Dragon Boat Festival': [(6, 12), (6, 13), (6, 14)],
             'Mid-Autumn Festival': [(9, 19), (9, 20), (9, 21)]
         },
+    2022:
+        {
+            'Ching Ming Festival': [(4, 3), (4, 4), (4, 5)],
+            'Labour Day Holiday': [(4, 30), (5, 1), (5, 2), (5, 3), (5, 4)],
+            'Dragon Boat Festival': [(6, 3), (6, 4), (6, 5)],
+            'Mid-Autumn Festival': [(9, 10), (9, 11), (9, 12)]
+        },
 }
 
 workdays = {
@@ -66,6 +73,13 @@ workdays = {
             'Mid-Autumn Festival Shift': [(9, 18)],
             'National Day Shift': [(9, 26), (10, 9)]
         },
+    2022:
+        {
+            'Spring Festival Shift': [(1, 29), (1, 30)],
+            'Ching Ming Festival Shift': [(4, 2)],
+            'Labour Day Holiday Shift': [(4, 24), (5, 7)],
+            'National Day Shift': [(10, 8), (10, 9)]
+        },
 }
 
 
@@ -73,6 +87,7 @@ workdays = {
 class China(ChineseNewYearCalendar):
     "China"
     # WARNING: Support 2018, 2019 currently, need update every year.
+    shift_new_years_day = True
     # National Days, 10.1 - 10.7
     national_days = [(10, i, "National Day") for i in range(1, 8)]
     FIXED_HOLIDAYS = tuple(national_days)

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -106,7 +106,8 @@ class ChinaTest(GenericCalendarTest):
 
         self.assertNotIn(date(2022, 1, 29), holidays)  # Spring Festival Shift
         self.assertNotIn(date(2022, 1, 30), holidays)  # Spring Festival Shift
-        self.assertNotIn(date(2022, 4, 2), holidays)  # Ching Ming Festival Shift
+        # Ching Ming Festival Shift
+        self.assertNotIn(date(2022, 4, 2), holidays)
         self.assertNotIn(date(2022, 4, 24), holidays)  # Labour Day Shift
         self.assertNotIn(date(2022, 5, 7), holidays)  # Labour Day Shift
         self.assertNotIn(date(2022, 10, 8), holidays)  # National Day Shift

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -87,6 +87,31 @@ class ChinaTest(GenericCalendarTest):
         self.assertNotIn(date(2021, 9, 26), holidays)  # National Day Shift
         self.assertNotIn(date(2021, 10, 9), holidays)  # National Day Shift
 
+    def test_year_2022(self):
+        holidays = self.cal.holidays_set(2022)
+        self.assertIn(date(2022, 1, 1), holidays)  # New Year
+        self.assertIn(date(2022, 1, 3), holidays)  # New Year
+        self.assertIn(date(2022, 1, 31), holidays)  # Spring Festival
+        self.assertIn(date(2022, 2, 6), holidays)  # Spring Festival
+        self.assertIn(date(2022, 4, 3), holidays)  # Ching Ming Festival
+        self.assertIn(date(2022, 4, 5), holidays)  # Ching Ming Festival
+        self.assertIn(date(2022, 4, 30), holidays)  # Labour Day Holiday
+        self.assertIn(date(2022, 5, 4), holidays)  # Labour Day Holiday
+        self.assertIn(date(2022, 6, 3), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2022, 6, 5), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2022, 9, 10), holidays)  # Mid-Autumn Festival
+        self.assertIn(date(2022, 9, 12), holidays)  # Mid-Autumn Festival
+        self.assertIn(date(2022, 10, 1), holidays)  # National Day
+        self.assertIn(date(2022, 10, 7), holidays)  # National Day
+
+        self.assertNotIn(date(2022, 1, 29), holidays)  # Spring Festival Shift
+        self.assertNotIn(date(2022, 1, 30), holidays)  # Spring Festival Shift
+        self.assertNotIn(date(2022, 4, 2), holidays)  # Ching Ming Festival Shift
+        self.assertNotIn(date(2022, 4, 24), holidays)  # Labour Day Shift
+        self.assertNotIn(date(2022, 5, 7), holidays)  # Labour Day Shift
+        self.assertNotIn(date(2022, 10, 8), holidays)  # National Day Shift
+        self.assertNotIn(date(2022, 10, 9), holidays)  # National Day Shift
+
     def test_missing_holiday_year(self):
         save_2018 = china_holidays[2018]
         del china_holidays[2018]
@@ -99,7 +124,7 @@ class ChinaTest(GenericCalendarTest):
         with patch('warnings.warn') as patched:
             self.cal.get_calendar_holidays(year)
         patched.assert_called_with(
-            'Support years 2018-2021 currently, need update every year.'
+            'Support years 2018-2022 currently, need update every year.'
         )
 
     def test_is_working_day(self):


### PR DESCRIPTION
Update China's public holidays for 2022.

refs #

http://www.gov.cn/zhengce/content/2021-10/25/content_5644835.htm