### PR TITLE
Add FederalReserveSystem calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- New calendar: Added USA Federal Reserve System calendar by @ludsoft (#695)
 
 ## v16.2.0 (2021-12-10)
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ from the command line.
   - Suffolk County, Massachusetts
   - California Education, Berkeley, San Francisco, West Hollywood
   - Florida Legal and Florida Circuit Courts, Miami-Dade
+  - Federal Reserve System
 
 ### Asia
 

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -21,6 +21,7 @@ from ..usa import (
     Utah, Vermont, Virginia, Washington, WestVirginia, Wisconsin, Wyoming,
     # Other territories, cities...
     AmericanSamoa, ChicagoIllinois, Guam, SuffolkCountyMassachusetts,
+    FederalReserveSystem,
 )
 
 
@@ -1931,3 +1932,33 @@ class ShiftExceptionsNextYearTestCase(UnitedStatesTest):
         # January 1st is a non-shift, Dec 31st should be a working day
         self.assertNotIn(date(2021, 12, 31), holidays)
         self.assertTrue(self.cal.is_working_day(date(2021, 12, 31)))
+
+
+class FederalReserveSystemTest(UnitedStatesTest):
+
+    cal_class = FederalReserveSystem
+
+    def test_juneteenth_day(self):
+
+        holidays = self.cal.holidays_set(2021)
+        juneteenth, _ = self.cal.get_juneteenth_day(2021)
+        self.assertEqual(date(2021, 6, 19), juneteenth)
+        # 2021-06-19 is a Saturday so holiday is shifted
+        self.assertIn(date(2021, 6, 18), holidays)
+
+        holidays = self.cal.holidays_set(2022)
+        juneteenth, _ = self.cal.get_juneteenth_day(2022)
+        self.assertEqual(date(2022, 6, 19), juneteenth)
+        # 2022-06-19 is a Sunday so holiday is shifted
+        self.assertIn(date(2022, 6, 20), holidays)
+
+        holidays = self.cal.holidays_set(2023)
+        juneteenth, _ = self.cal.get_juneteenth_day(2023)
+        self.assertEqual(date(2023, 6, 19), juneteenth)
+        self.assertIn(juneteenth, holidays)
+
+        # No JuneTeeth before 2021
+        holidays = self.cal.holidays_set(2020)
+        self.assertNotIn(date(2020, 6, 20), holidays)
+        with self.assertRaises(ValueError):
+            self.cal.get_juneteenth_day(2020)

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -1,4 +1,4 @@
-from .core import UnitedStates
+from .core import UnitedStates, FederalReserveSystem
 
 from .alabama import (
     Alabama, AlabamaBaldwinCounty, AlabamaMobileCounty, AlabamaPerryCounty)
@@ -122,4 +122,5 @@ __all__ = [
     # Non-State territories
     'AmericanSamoa',
     'Guam',
+    'FederalReserveSystem'
 ]

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -1,7 +1,6 @@
 from datetime import date, timedelta
 
-from ..core import WesternCalendar
-from ..core import SUN, MON, TUE, THU, SAT
+from ..core import MON, SAT, SUN, THU, TUE, WesternCalendar
 from ..registry_tools import iso_register
 
 
@@ -61,6 +60,9 @@ class UnitedStates(WesternCalendar):
     # Some regional variants
     include_fat_tuesday = False
     fat_tuesday_label = "Mardi Gras"
+
+    # Juneteenth
+    include_juneteenth = False
 
     # Shift day mechanism
     # These days won't be shifted to next MON or previous FRI
@@ -259,6 +261,15 @@ class UnitedStates(WesternCalendar):
             self.national_memorial_day_label
         )
 
+    def get_juneteenth_day(self, year):
+        """
+        Return Juneteenth Day
+        """
+        # Juneteenth started to be a federal holiday in 2021
+        if year < 2021:
+            raise ValueError("Juneteenth became a federal holiday in 2021")
+        return (date(year, 6, 19), "Juneteenth National Independence Day")
+
     def get_variable_days(self, year):
         # usual variable days
         days = super().get_variable_days(year)
@@ -314,6 +325,9 @@ class UnitedStates(WesternCalendar):
                 self.get_thanksgiving_friday(year)
             )
 
+        if self.include_juneteenth and year >= 2021:
+            days.append(self.get_juneteenth_day(year))
+
         return days
 
     def get_veterans_day(self, year):
@@ -337,3 +351,9 @@ class UnitedStates(WesternCalendar):
         days = super().get_calendar_holidays(year)
         days = self.shift(days, year)
         return days
+
+
+class FederalReserveSystem(UnitedStates):
+    "Board of Governors of the Federal Reserve System of the USA"
+
+    include_juneteenth = True


### PR DESCRIPTION
refs #

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [ ] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.md file.
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

This is adding the calendar for the federal reserve: https://www.federalreserve.gov/aboutthefed/k8.htm

To do so I needed to add Juneteenth and found this issue:  #661 and tried to follow the logic proposed there.
As I was not sure how to test only adding Juneteenth without a calendar using it, both are in a single pull request. Let me know if you would like to split it.

Thanks! 

