### PR TITLE
Doc: Fix the ``keep_datetime`` usage example in the "basic" doc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,8 @@
 - New calendar: Added Kazakhstan calendar by @atj01 (#688).
 - New calendar: Added Georgia (country) calendar by @atj01 (#687).
 - Added conditional holidays on 26th December and 2nd January in Neuchatel (Switzerland) (#697).
-- Added Federal Thanksgiving Monday and two conditional holidays on 26th December
-  and 2nd January in Neuchatel (Switzerland) (#697).
+- Added Federal Thanksgiving Monday and two conditional holidays on 26th December and 2nd January in Neuchatel (Switzerland) (#697).
+- Documentation: Fix the ``keep_datetime`` usage example in the "basic" doc (#690).
 
 ## v16.2.0 (2021-12-10)
 

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -96,10 +96,10 @@ Example:
 >>> cal.is_working_day(datetime(2012, 12, 25, 14, 0, 39))
 False
 >>> cal.add_working_days(datetime(2012, 12, 23, 14, 0, 39), 5)
-datetime.datetime(2012, 12, 31)
+datetime.date(2012, 12, 31)
 ```
 
-If you really need it, you can use the ``add_working_days()`` with an option that will keep the ``datetime`` type:
+You see that the default result type is ``datetime.date``. But if you really need it, you can use the ``keep_datetime`` option to return the result with the input type:
 
 ```python
 >>> from datetime import date, datetime


### PR DESCRIPTION
closes #690

- [x] Changelog amended with a mention describing your changes.