### PR TITLE
Feature/thuringa children day

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Added International Children's Day 20th September in Thuringa (Germany) (#713).
 
 ## v16.3.0 (2022-02-22)
 

--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -195,3 +195,13 @@ class Thuringia(Germany):
     'Thuringia'
 
     all_time_include_reformation_day = True
+
+    def get_international_children_day(self, year):
+        day = date(year, 9, 20)
+        return day, "International Childrens's Day"
+
+    def get_variable_days(self, year):
+        days = super().get_variable_days(year)
+        if year >= 2019:
+            days.append(self.get_international_children_day(year))
+        return days

--- a/workalendar/tests/test_germany.py
+++ b/workalendar/tests/test_germany.py
@@ -311,3 +311,15 @@ class ThuringiaTest(GermanyTest):
     def test_extra_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 10, 31), holidays)
+
+    def test_extra_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertNotIn(date(2018, 9, 20), holidays)
+
+    def test_extra_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 9, 20), holidays)
+
+    def test_extra_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 9, 20), holidays)


### PR DESCRIPTION
refs #713

- [X] Tests with a significant number of years to be tested for your calendar.
- [X] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

