### PR TITLE
Update UK to include State Funeral Bank Holiday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Fixed United Kingdom's 2022 holidays ; Added Bank Holiday for the State Funeral of Queen Elizabeth II
 
 ## v16.3.0 (2022-02-22)
 

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -20,7 +20,8 @@ class UnitedKingdom(WesternCalendar):
         2002: [(date(2002, 6, 3), "Queen’s Golden Jubilee"), ],
         2011: [(date(2011, 4, 29), "Royal Wedding"), ],
         2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee"), ],
-        2022: [(date(2022, 6, 3), "Queen’s Platinum Jubilee bank holiday"), ],
+        2022: [(date(2022, 6, 3), "Queen’s Platinum Jubilee bank holiday"),
+               (date(2022, 9, 19), "State Funeral of Queen Elizabeth II"), ],
     }
 
     def get_early_may_bank_holiday(self, year):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1936,7 +1936,6 @@ class UnitedKingdomTest(GenericCalendarTest):
 
     def test_2022(self):
         holidays = self.cal.holidays_set(2022)
-        print(holidays)
         self.assertIn(date(2022, 1, 3), holidays)  # New Year
         self.assertIn(date(2022, 4, 15), holidays)  # Good Friday
         self.assertIn(date(2022, 4, 18), holidays)  # Easter Monday
@@ -1946,6 +1945,7 @@ class UnitedKingdomTest(GenericCalendarTest):
         # Platinum Jubilee Bank Holiday
         self.assertIn(date(2022, 6, 3), holidays)
         self.assertIn(date(2022, 8, 29), holidays)  # Summer bank holiday
+        self.assertIn(date(2022, 9, 19), holidays)  # State Funeral of Queen Elizabeth II
         self.assertIn(date(2022, 12, 26), holidays)  # Boxing Day
         self.assertIn(date(2022, 12, 27), holidays)  # Christmas Day
 

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1945,7 +1945,8 @@ class UnitedKingdomTest(GenericCalendarTest):
         # Platinum Jubilee Bank Holiday
         self.assertIn(date(2022, 6, 3), holidays)
         self.assertIn(date(2022, 8, 29), holidays)  # Summer bank holiday
-        self.assertIn(date(2022, 9, 19), holidays)  # State Funeral of Queen Elizabeth II
+        # State Funeral of Queen Elizabeth II
+        self.assertIn(date(2022, 9, 19), holidays)
         self.assertIn(date(2022, 12, 26), holidays)  # Boxing Day
         self.assertIn(date(2022, 12, 27), holidays)  # Christmas Day
 


### PR DESCRIPTION
[State Funeral Announcement](https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september)

<!-- if your contribution is a fix -->

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

