### PR TITLE
Add Coronation of His Majesty King Charles III Bank holiday in 2023 to the UK calendar.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Coronation of His Majesty King Charles III Bank holiday in 2023 to the UK calendar.
 
 ## v17.0.0 (2023-01-01)
 

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -22,6 +22,9 @@ class UnitedKingdom(WesternCalendar):
         2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee"), ],
         2022: [(date(2022, 6, 3), "Queen’s Platinum Jubilee bank holiday"),
                (date(2022, 9, 19), "State Funeral of Queen Elizabeth II"), ],
+        2023: [
+            (date(2023, 5, 8), "Coronation of His Majesty King Charles III"),
+        ],
     }
 
     def get_early_may_bank_holiday(self, year):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1950,6 +1950,19 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2022, 12, 26), holidays)  # Boxing Day
         self.assertIn(date(2022, 12, 27), holidays)  # Christmas Day
 
+    def test_2023(self):
+        holidays = self.cal.holidays_set(2023)
+        self.assertIn(date(2023, 1, 2), holidays)  # New Year
+        self.assertIn(date(2023, 4, 7), holidays)  # Good Friday
+        self.assertIn(date(2023, 4, 10), holidays)  # Easter Monday
+        self.assertIn(date(2023, 5, 1), holidays)  # Early May Bank Holiday
+        # Coronation of His Majesty King Charles III
+        self.assertIn(date(2023, 5, 8), holidays)
+        self.assertIn(date(2023, 5, 29), holidays)  # Spring Bank Holidays
+        self.assertIn(date(2023, 8, 28), holidays)  # Summer bank holiday
+        self.assertIn(date(2023, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2023, 12, 26), holidays)  # Boxing Day
+
 
 class UnitedKingdomNorthernIrelandTest(UnitedKingdomTest):
     cal_class = UnitedKingdomNorthernIreland


### PR DESCRIPTION
[GOV.UK Press release](https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii)

<!-- if your contribution is a fix -->

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

