### PR TITLE
Upgrade python and tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
         include:
           - python-version: 3.7
             tox-env: py37
@@ -51,6 +51,8 @@ jobs:
             tox-env: py39
           - python-version: '3.10'
             tox-env: py310
+          - python-version: 3.11
+            tox-env: py311
 
     name: Test (python ${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         include:
           - python-version: 3.7
             tox-env: py37
@@ -49,6 +49,8 @@ jobs:
             tox-env: py38
           - python-version: 3.9
             tox-env: py39
+          - python-version: '3.10'
+            tox-env: py310
 
     name: Test (python ${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Removed compatibility with Python 3.6, also, removed tests & amended documentation (#705).
 - Upgraded `tox` usage, now compatble with tox 4+ (added `allowlist_externals`).
+- Added support for Python 3.10 (#706).
 
 ## v16.4.0 (2022-09-16)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Removed compatibility with Python 3.6, also, removed tests & amended documentation (#705).
 - Upgraded `tox` usage, now compatble with tox 4+ (added `allowlist_externals`).
 - Added support for Python 3.10 (#706).
+- Added support for Python 3.11 (#732).
 
 ## v16.4.0 (2022-09-16)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Removed compatibility with Python 3.6, also, removed tests & amended documentation (#705).
+- Upgraded `tox` usage, now compatble with tox 4+ (added `allowlist_externals`).
 
 ## v16.4.0 (2022-09-16)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For a more complete documentation and advanced usage, go to [the official workal
 
 **Workalendar will require you to use Python 3.7+.**
 
-Workalendar is tested on Python 3.7, 3.8, 3.9, and on Linux (Ubuntu), Mac OS and Windows using Github actions.
+Workalendar is tested on Python 3.7, 3.8, 3.9, 3.10, and on Linux (Ubuntu), Mac OS and Windows using Github actions.
 
 ### Conditional dependencies
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For a more complete documentation and advanced usage, go to [the official workal
 
 **Workalendar will require you to use Python 3.7+.**
 
-Workalendar is tested on Python 3.7, 3.8, 3.9, 3.10, and on Linux (Ubuntu), Mac OS and Windows using Github actions.
+Workalendar is tested on Python 3.7, 3.8, 3.9, 3.10, 3.11, and on Linux (Ubuntu), Mac OS and Windows using Github actions.
 
 ### Conditional dependencies
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ pip install -e ./
 When you provide a patch for workalendar, whether it would be a new calendar or a fix to an existing one, or else, you will have to make sure that your contribution follows these basic requirements:
 
 * Your code should pass the `flake8` test ; that is to say that it follows the [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines. You can check using the `tox -e flake8` command. If you can't, our CI jobs will do it, and you'll be able to know where are your mistakes, if any.
-* Your code should be compatible with our supported Python version. Currently: Python 3.7, 3.8, 3.9 and 3.10. Again, the CI (powered by Github Actions) will check your code against all those versions so you won't have to.
+* Your code should be compatible with our supported Python version. Currently: Python 3.7, 3.8, 3.9, 3.10 and 3.11. Again, the CI (powered by Github Actions) will check your code against all those versions so you won't have to.
 * If you encounter a failure in the `pyupgrade` tox job, you can fix it by running the followinf command: `tox -r pyupgrade`. It'll modify your code so it will pass this test. **Warning:** sometimes, this change can break the `flake8` standards, so you'll have to make sure that both linters will pass.
 
 #### Test-driven start

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ pip install -e ./
 When you provide a patch for workalendar, whether it would be a new calendar or a fix to an existing one, or else, you will have to make sure that your contribution follows these basic requirements:
 
 * Your code should pass the `flake8` test ; that is to say that it follows the [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines. You can check using the `tox -e flake8` command. If you can't, our CI jobs will do it, and you'll be able to know where are your mistakes, if any.
-* Your code should be compatible with our supported Python version. Currently: Python 3.7, 3.8 and 3.9. Again, the CI (powered by Github Actions) will check your code against all those versions so you won't have to.
+* Your code should be compatible with our supported Python version. Currently: Python 3.7, 3.8, 3.9 and 3.10. Again, the CI (powered by Github Actions) will check your code against all those versions so you won't have to.
 * If you encounter a failure in the `pyupgrade` tox job, you can fix it by running the followinf command: `tox -r pyupgrade`. It'll modify your code so it will pass this test. **Warning:** sometimes, this change can break the `flake8` standards, so you'll have to make sure that both linters will pass.
 
 #### Test-driven start

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pyupgrade,flake8,py37,py38,py39,py310
+envlist = pyupgrade,flake8,py37,py38,py39,py310,py311
 
 [testenv]
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,10 @@
 envlist = pyupgrade,flake8,py37,py38,py39
 
 [testenv]
+allowlist_externals =
+    flake8
+    py.test
+    pyup_dirs
 deps =
     pytest
     pandas

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pyupgrade,flake8,py37,py38,py39
+envlist = pyupgrade,flake8,py37,py38,py39,py310
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
* Upgraded usage of `tox` (now compatible with tox v4+)
* Added compatibility with Python 3.10 & 3.11

refs #706, #732


