### PR TITLE
add Liechtenstein

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Coronation of His Majesty King Charles III Bank holiday in 2023 to the UK calendar.
+- New calendar: Added Liechtenstein calendar by @barilla-aldente
 
 ## v17.0.0 (2023-01-01)
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ from the command line.
 - Ireland
 - Italy
 - Latvia
+- Liechtenstein
 - Lithuania
 - Luxembourg
 - Malta

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -93,6 +93,7 @@ class ChristianMixin:
     include_christmas_eve = False
     include_ascension = False
     include_assumption = False
+    assumption_label = "Assumption of Mary to Heaven"
     include_whit_sunday = False
     whit_sunday_label = 'Whit Sunday'
     include_whit_monday = False
@@ -213,7 +214,7 @@ class ChristianMixin:
         if self.include_easter_monday:
             days.append((self.get_easter_monday(year), "Easter Monday"))
         if self.include_assumption:
-            days.append((date(year, 8, 15), "Assumption of Mary to Heaven"))
+            days.append((date(year, 8, 15), self.assumption_label))
         if self.include_all_saints:
             days.append((date(year, 11, 1), "All Saints Day"))
         if self.include_all_souls:

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -19,6 +19,7 @@ from .iceland import Iceland
 from .ireland import Ireland
 from .italy import Italy
 from .latvia import Latvia
+from .liechtenstein import Liechtenstein
 from .lithuania import Lithuania
 from .luxembourg import Luxembourg
 from .malta import Malta
@@ -91,6 +92,7 @@ __all__ = (
     'Ireland',
     'Italy',
     'Latvia',
+    'Liechtenstein',
     'Lithuania',
     'Luxembourg',
     'Malta',

--- a/workalendar/europe/liechtenstein.py
+++ b/workalendar/europe/liechtenstein.py
@@ -1,0 +1,62 @@
+from datetime import date
+from ..core import WesternCalendar
+from ..registry_tools import iso_register
+
+
+@iso_register("LI")
+class Liechtenstein(WesternCalendar):
+    "Liechtenstein"
+
+    # Public Holyday
+    include_epiphany = True
+    include_easter_sunday = True
+    include_easter_monday = True
+    include_labour_day = True
+    include_ascension = True
+    include_whit_sunday = True
+    include_whit_monday = True
+    include_corpus_christi = True
+    include_assumption = True  # National Day
+    include_nativity_of_mary = True
+    include_all_saints = True
+    include_immaculate_conception = True
+    include_christmas = True
+    include_boxing_day = True
+    boxing_day_label = "St. Stephen's Day"  # Stefanstag
+
+    # bank holydays
+    fat_tuesday_label = "Shrove Tuesday"
+
+    def __init__(self, include_rest_days=True, include_bankholyday=False):
+        # legally public rest days
+        self.include_candlemas = include_rest_days
+        self.include_st_josephs_day = include_rest_days
+
+        # bank holydays
+        self.include_berchtolds_day = include_bankholyday
+        self.include_fat_tuesday = include_bankholyday
+        self.include_good_friday = include_bankholyday
+        self.include_christmas_eve = include_bankholyday
+        self.include_new_years_eve = include_bankholyday
+
+        super().__init__()
+
+    def has_berchtolds_day(self, year):
+        return self.include_berchtolds_day
+
+    def get_variable_days(self, year):
+        days = super().get_variable_days(year)
+
+        if self.has_berchtolds_day(year):
+            days.append((date(year, 1, 2), "Berchtold's Day"))
+
+        if self.include_st_josephs_day:
+            days.append((date(year, 3, 19), "St Joseph's Day"))
+
+        if self.include_candlemas:
+            days.append((date(year, 2, 2), "Candlemas"))
+
+        if self.include_candlemas:
+            days.append((date(year, 9, 8), "Nativity of Mary"))
+
+        return days

--- a/workalendar/europe/liechtenstein.py
+++ b/workalendar/europe/liechtenstein.py
@@ -28,6 +28,8 @@ class Liechtenstein(WesternCalendar):
     fat_tuesday_label = "Shrove Tuesday"
 
     def __init__(self, include_rest_days=True, include_bankholyday=False):
+
+        self.assumption_label = "State holiday and " + super().assumption_label
         # legally public rest days
         self.include_candlemas = include_rest_days
         self.include_st_josephs_day = include_rest_days

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -27,6 +27,7 @@ from ..europe import (
     Ireland,
     Italy,
     Latvia,
+    Liechtenstein,
     Lithuania,
     Luxembourg,
     Malta,
@@ -1028,6 +1029,28 @@ class LatviaTest(GenericCalendarTest):
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
         self.assertIn(date(2013, 5, 6), holidays)  # Restoration Day Observed
+
+
+class LiechtensteinTest(GenericCalendarTest):
+    cal_class = Liechtenstein
+
+    def test_year_2016(self):
+        holidays = self.cal.holidays_set(2016)
+        self.assertIn(date(2016, 1, 1), holidays)  # New Years day
+        self.assertIn(date(2016, 1, 6), holidays)  # Epiphany
+        self.assertIn(date(2016, 2, 2), holidays)  # Candelmass
+        self.assertIn(date(2016, 3, 19), holidays)  # Saint Joseph's Day
+        self.assertIn(date(2016, 3, 28), holidays)  # easter monday
+        self.assertIn(date(2016, 5, 1), holidays)  # Labour day
+        self.assertIn(date(2016, 5, 5), holidays)  # Ascension Day
+        self.assertIn(date(2016, 5, 16), holidays)  # Whit monday
+        self.assertIn(date(2016, 5, 26), holidays)  # Corpus Christi
+        self.assertIn(date(2016, 8, 15), holidays)  # Assumption & National Day
+        self.assertIn(date(2016, 9, 8), holidays)  # Nativity of Mary
+        self.assertIn(date(2016, 11, 1), holidays)  # all saints
+        self.assertIn(date(2016, 12, 8), holidays)  # Immaculate conception
+        self.assertIn(date(2016, 12, 25), holidays)  # Xmas
+        self.assertIn(date(2016, 12, 26), holidays)  # St Stephens
 
 
 class LuxembourgTest(GenericCalendarTest):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1033,13 +1033,17 @@ class LatviaTest(GenericCalendarTest):
 
 class LiechtensteinTest(GenericCalendarTest):
     cal_class = Liechtenstein
+    kwargs = dict(include_rest_days=True, include_bankholyday=True)
 
     def test_year_2016(self):
         holidays = self.cal.holidays_set(2016)
         self.assertIn(date(2016, 1, 1), holidays)  # New Years day
+        self.assertIn(date(2016, 1, 2), holidays)  # Berchtold's Day
         self.assertIn(date(2016, 1, 6), holidays)  # Epiphany
         self.assertIn(date(2016, 2, 2), holidays)  # Candelmass
+        self.assertIn(date(2016, 2, 9), holidays)  # Shrove Tuesday
         self.assertIn(date(2016, 3, 19), holidays)  # Saint Joseph's Day
+        self.assertIn(date(2016, 3, 25), holidays)  # Good Friday
         self.assertIn(date(2016, 3, 28), holidays)  # easter monday
         self.assertIn(date(2016, 5, 1), holidays)  # Labour day
         self.assertIn(date(2016, 5, 5), holidays)  # Ascension Day
@@ -1049,8 +1053,10 @@ class LiechtensteinTest(GenericCalendarTest):
         self.assertIn(date(2016, 9, 8), holidays)  # Nativity of Mary
         self.assertIn(date(2016, 11, 1), holidays)  # all saints
         self.assertIn(date(2016, 12, 8), holidays)  # Immaculate conception
+        self.assertIn(date(2016, 12, 24), holidays)  # Xmas Eve
         self.assertIn(date(2016, 12, 25), holidays)  # Xmas
         self.assertIn(date(2016, 12, 26), holidays)  # St Stephens
+        self.assertIn(date(2016, 12, 31), holidays)  # New Year's Eve
 
 
 class LuxembourgTest(GenericCalendarTest):


### PR DESCRIPTION
refs #
https://de.wikipedia.org/wiki/Feiertage_in_Liechtenstein
https://en.wikipedia.org/wiki/Public_holidays_in_Liechtenstein


For information, read and make sure you're okay with the [Contributing guidelines](https://workalendar.github.io/workalendar/contributing.html#adding-new-calendars).

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.md file.
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

