### PR TITLE
feature: new school holidays published by Dutch government

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,11 +28,11 @@ For information, read and make sure you're okay with the [Contributing guideline
     - [ ] Add the "master / nothing to see here" in Changelog.md
     - [ ] Push & wait for the tests to be green
 - [ ] Merge --ff
-- Github stuff
+- GitHub stuff
     - [ ] Push tag in Github
-    - [ ] Edit release on Github using the changelog.
+    - [ ] Edit release on GitHub using the changelog.
     - [ ] Delete branch
 - [ ] upload release on PyPI using ``twine``
-- [ ] (*optional*) Make feeback on the various PR or issues.
+- [ ] (*optional*) Make feedback on the various PR or issues.
 
  -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11]
         include:
-          - python-version: 3.7
-            tox-env: py37
           - python-version: 3.8
             tox-env: py38
           - python-version: 3.9

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@
 
 - Update China's public holidays for 2023 (#728).
 - Removed compatibility with Python 3.6, also, removed tests & amended documentation (#705).
-- Upgraded `tox` usage, now compatble with tox 4+ (added `allowlist_externals`).
+- Upgraded `tox` usage, now compatible with tox 4+ (added `allowlist_externals`).
 - Added support for Python 3.10 (#706).
 - Added support for Python 3.11 (#732).
 - Refactor ``NetherlandsWithSchoolHolidays.get_christmas_holidays`` for simplicity and readability.
@@ -186,7 +186,7 @@
 
 ### Other changes
 
-- Switched from Travis CI to Github Actions for CI jobs, thanks to @mgu.
+- Switched from Travis CI to GitHub Actions for CI jobs, thanks to @mgu.
 - Added support of Python 3.9 (#557).
 - Changed from `setup.py` to a nice `setup.cfg` file, thanks @ewjoachim (#576).
 - Use the `setup.cfg` file in the key to cache in `ci.yml` file (#587).
@@ -624,7 +624,7 @@ Large work on global registry: refs #13, #96, #257 & #284.
 - Added a `keep_datetime` option to keep the original type of the input argument for both ``add_working_days()`` and ``sub_working_days()`` functions (#270).
 - Fixed usage examples of ``get_first_weekday_after()`` docstring + in code (calendars and tests) ; do not use magic values, use MON, TUE, etc (#271).
 - Turned Changelog into a Markdown file (#272).
-- Added basic usage documentation, hosted by Github pages.
+- Added basic usage documentation, hosted by GitHub pages.
 - Added advanced usage documentation.
 
 ## v2.5.0 (2018-06-14)
@@ -667,7 +667,7 @@ I have done a terrible mistake with the 1.3.0 release, and uploaded a defunct 2.
 
 ## v2.0.0 (2017-06-23)
 
-- Major refactor in the USA module. Each State is now an independant module, all of the Mixins were removed, all the possible corrections have been made, following the main Wikipedia page, and cross-checking with official sources when it was possible (#171).
+- Major refactor in the USA module. Each State is now an independent module, all of the Mixins were removed, all the possible corrections have been made, following the main Wikipedia page, and cross-checking with official sources when it was possible (#171).
 - Added District of Columbia in the USA module (#217).
 - Run tests with Python3.6 in CI (#210)
 - Small refactors / cleanups in the following calendars: Hungary, Iceland, Ireland, Latvia, Netherlands, Spain, Japan, Taiwan, Australia, Canada, USA (#209).

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Coronation of His Majesty King Charles III Bank holiday in 2023 to the UK calendar.
+- New dates for school holidays in the Netherlands from 2026 until 20230.
 
 ## v17.0.0 (2023-01-01)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,7 +6,7 @@
 
 If you are using `workalendar`, you are already contributing to it. As long as you are able to check its result, compare the designated working days and holidays to the reality, and make sure these are right, you're helping.
 
-If any of the computed holidays for the country / area your are using is **wrong**, please report [it using the Github issues](https://github.com/workalendar/workalendar/issues).
+If any of the computed holidays for the country / area you are using is **wrong**, please report [it using the Github issues](https://github.com/workalendar/workalendar/issues).
 
 ## Report an issue
 
@@ -56,7 +56,7 @@ Here is a list of the holidays in *Zhraa*:
 
 #### Getting ready
 
-You'll need to install `workalendar` dependencies beforehand. What's great is that you'll use virtualenv to set it up. Or even better: `virtualenvwrapper`. Just go in your working copy (cloned from github) of workalendar and type, for example:
+You'll need to install `workalendar` dependencies beforehand. What's great is that you'll use virtualenv to set it up. Or even better: `virtualenvwrapper`. Just go in your working copy (cloned from GitHub) of workalendar and type, for example:
 
 ```sh
 mkvirtualenv WORKALENDAR

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -60,6 +60,11 @@ class Netherlands(WesternCalendar):
 
 
 FALL_HOLIDAYS_EARLY_REGIONS = {
+    2030: ["south"],  # best guess as of November 2023
+    2029: ["south"],
+    2028: ["north"],
+    2027: ["north", "middle"],
+    2026: ["north"],
     2025: ["south"],
     2024: ["south"],
     2023: ["middle", "south"],
@@ -73,6 +78,11 @@ FALL_HOLIDAYS_EARLY_REGIONS = {
 }
 
 SPRING_HOLIDAYS_EARLY_REGIONS = {
+    2030: ["north"],
+    2029: ["south"],
+    2028: ["north"],
+    2027: ["south"],
+    2026: ["middle", "south"],
     2025: ["north"],
     2024: ["south"],
     2023: ["south"],
@@ -86,6 +96,11 @@ SPRING_HOLIDAYS_EARLY_REGIONS = {
 }
 
 SUMMER_HOLIDAYS_EARLY_REGIONS = {
+    2030: ["south"],
+    2029: ["middle"],
+    2028: ["middle"],
+    2027: ["north"],
+    2026: ["north"],
     2025: ["south"],
     2024: ["south"],
     2023: ["middle"],
@@ -99,6 +114,11 @@ SUMMER_HOLIDAYS_EARLY_REGIONS = {
 }
 
 SUMMER_HOLIDAYS_LATE_REGIONS = {
+    2030: ["north"],
+    2029: ["north"],
+    2028: ["south"],
+    2027: ["south"],
+    2026: ["middle"],
     2025: ["middle"],
     2024: ["north"],
     2023: ["north"],
@@ -209,7 +229,7 @@ class NetherlandsWithSchoolHolidays(Netherlands):
         week = 9
 
         # Exceptional years
-        if year in [2024, 2021]:
+        if year in [2029, 2027, 2024, 2021]:
             week = 8
 
         # Holiday starts on the preceding Saturday
@@ -249,7 +269,7 @@ class NetherlandsWithSchoolHolidays(Netherlands):
         week = 18
 
         # Exceptional years
-        if year == 2017:
+        if year in [2027, 2017]:
             week = 17
 
         # Holiday starts on the preceding Saturday

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1222,6 +1222,101 @@ class NetherlandsNorthWithSchoolHolidaysTest(GenericCalendarTest):
             christmas_holiday_end,
         )
 
+    def test_year_2025(self):
+        year = 2025
+        christmas_holiday_end = date(year, 1, 5)
+        spring_holiday_start = date(year, 2, 15)
+        may_holiday_start = date(year, 4, 26)
+        summer_holiday_start = date(year, 7, 12)
+        fall_holiday_start = date(year, 10, 18)
+        christmas_holiday_start = date(year, 12, 20)
+
+        self._test_school_holidays(
+            year,
+            christmas_holiday_start,
+            spring_holiday_start,
+            may_holiday_start,
+            summer_holiday_start,
+            fall_holiday_start,
+            christmas_holiday_end,
+        )
+
+    def test_year_2026(self):
+        year = 2026
+        christmas_holiday_end = date(year, 1, 4)
+        spring_holiday_start = date(year, 2, 21)
+        may_holiday_start = date(year, 4, 25)
+        summer_holiday_start = date(year, 7, 4)
+        fall_holiday_start = date(year, 10, 10)
+        christmas_holiday_start = date(year, 12, 19)
+
+        self._test_school_holidays(
+            year,
+            christmas_holiday_start,
+            spring_holiday_start,
+            may_holiday_start,
+            summer_holiday_start,
+            fall_holiday_start,
+            christmas_holiday_end,
+        )
+
+    def test_year_2027(self):
+        year = 2027
+        christmas_holiday_end = date(year, 1, 3)
+        spring_holiday_start = date(year, 2, 20)
+        may_holiday_start = date(year, 4, 24)
+        summer_holiday_start = date(year, 7, 10)
+        fall_holiday_start = date(year, 10, 16)
+        christmas_holiday_start = date(year, 12, 25)
+
+        self._test_school_holidays(
+            year,
+            christmas_holiday_start,
+            spring_holiday_start,
+            may_holiday_start,
+            summer_holiday_start,
+            fall_holiday_start,
+            christmas_holiday_end,
+        )
+
+    def test_year_2028(self):
+        year = 2028
+        christmas_holiday_end = date(year, 1, 9)
+        spring_holiday_start = date(year, 2, 19)
+        may_holiday_start = date(year, 4, 29)
+        summer_holiday_start = date(year, 7, 15)
+        fall_holiday_start = date(year, 10, 14)
+        christmas_holiday_start = date(year, 12, 23)
+
+        self._test_school_holidays(
+            year,
+            christmas_holiday_start,
+            spring_holiday_start,
+            may_holiday_start,
+            summer_holiday_start,
+            fall_holiday_start,
+            christmas_holiday_end,
+        )
+
+    def test_year_2029(self):
+        year = 2029
+        christmas_holiday_end = date(year, 1, 7)
+        spring_holiday_start = date(year, 2, 17)
+        may_holiday_start = date(year, 4, 28)
+        summer_holiday_start = date(year, 7, 21)
+        fall_holiday_start = date(year, 10, 20)
+        christmas_holiday_start = date(year, 12, 22)
+
+        self._test_school_holidays(
+            year,
+            christmas_holiday_start,
+            spring_holiday_start,
+            may_holiday_start,
+            summer_holiday_start,
+            fall_holiday_start,
+            christmas_holiday_end,
+        )
+
     def _test_school_holidays(
             self,
             year,


### PR DESCRIPTION
New dates for school holidays until school year 2029-2030 have been published by the Dutch government (see [rijksoverheid.nl](https://www.rijksoverheid.nl/onderwerpen/schoolvakanties/overzicht-schoolvakanties-per-schooljaar)).
This PR updates the NL school holidays until 2030 (excluding the 2030 fall holiday, which falls in the yet unpublished 2030/2031 school year).

refs #

<!-- if your contribution is a fix -->

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

<!-- Release management

- Commit for the tag:
    - [ ] Edit version in setup.cfg
    - [ ] Add version in Changelog.md ; trim things
    - [ ] Push & wait for the tests to be green
    - [ ] tag me.
    - [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [ ] Edit version in setup.cfg
    - [ ] Add the "master / nothing to see here" in Changelog.md
    - [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feedback on the various PR or issues.

 -->
