### PR TITLE
Berlin: 2025 Liberation Day

### DIFF
--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -88,7 +88,7 @@ class Berlin(Germany):
         days = super().get_variable_days(year)
         if year >= 2019:
             days.append(self.get_international_womens_day(year))
-        if year == 2020:
+        if year in (2020, 2025):
             days.append(self.get_liberation_day(year))
         return days
 


### PR DESCRIPTION
80th anniversary Liberation Day
https://www.berlin.de/en/news/9188766-5559700-oneoff-public-holiday-on-8-may-2025.en.html

<!-- if your contribution is a fix -->

- [ ] Tests with a significant number of years to be tested for your calendar.
- [ ] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

Fix is trivial, test for functionality already exists for 2020.